### PR TITLE
Bump picomatch from 2.3.1 to 2.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "jcbaptiste",
+  "name": "practical-mayer",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "practical-mayer",
       "dependencies": {
         "watchy": "^0.10.0"
       }
@@ -166,9 +167,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "engines": {
         "node": ">=8.6"
       },


### PR DESCRIPTION
Fixes two high severity vulnerabilities:
- GHSA-3v7f-55p6-f55p: Method Injection in POSIX Character Classes
- GHSA-c2c7-rcm5-vvqj: ReDoS via extglob quantifiers